### PR TITLE
Remove codecov requirement on pull requests to codecov branch

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,7 +4,7 @@ on:
     push:
         branches: [main, test, codecov]
     pull_request:
-        branches: [main, test, codecov]
+        branches: [main, test]
 
 env:
     JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}


### PR DESCRIPTION
Since codecov is the branch where we extend test coverage, it makes sense to be able to merge new code into this branch even if it brings codecov's code coverage down. This pull request simply removes the requirement that branches merging into codecov need to improve codecov's code coverage score.