### PR TITLE
Added fields for versioning support

### DIFF
--- a/backend/src/file_manager/__mocks__/file_manager.service.ts
+++ b/backend/src/file_manager/__mocks__/file_manager.service.ts
@@ -106,6 +106,8 @@ export class FileManagerServiceMock {
         ParentFolderID: file.ParentFolderID,
         Content: '',
         SafeLock: false,
+        NextDiffID: file.NextDiffID,
+        NextSnapshotID: file.NextSnapshotID,
       };
       markdownFilesDTOArr.push(markdownFileDTO);
     });

--- a/backend/src/file_manager/file_manager.controller.spec.ts
+++ b/backend/src/file_manager/file_manager.controller.spec.ts
@@ -866,6 +866,8 @@ describe('FileManagerController', () => {
       markdownFileDTO.MarkdownID = '123';
       markdownFileDTO.UserID = 123;
       markdownFileDTO.Content = ' ';
+      markdownFileDTO.NextDiffID = 0;
+      markdownFileDTO.NextSnapshotID = 0;
 
       jest
         .spyOn(fileManagerService, 'saveFile')

--- a/backend/src/file_manager/file_manager.service.spec.ts
+++ b/backend/src/file_manager/file_manager.service.spec.ts
@@ -838,6 +838,8 @@ describe('FileManagerService', () => {
         ParentFolderID: '1',
         Size: 100,
         SafeLock: false,
+        NextDiffID: 0,
+        NextSnapshotID: 0,
       };
       const file2: MarkdownFile = {
         MarkdownID: '2',
@@ -849,6 +851,8 @@ describe('FileManagerService', () => {
         ParentFolderID: '1',
         Size: 100,
         SafeLock: false,
+        NextDiffID: 0,
+        NextSnapshotID: 0,
       };
       const files = [file1, file2];
 
@@ -959,6 +963,8 @@ describe('FileManagerService', () => {
           ParentFolderID: '1',
           Size: 100,
           SafeLock: false,
+          NextDiffID: 0,
+          NextSnapshotID: 0,
         },
         {
           MarkdownID: '2',
@@ -970,6 +976,8 @@ describe('FileManagerService', () => {
           ParentFolderID: '1',
           Size: 100,
           SafeLock: false,
+          NextDiffID: 0,
+          NextSnapshotID: 0,
         },
       ];
 

--- a/backend/src/file_manager/file_manager.service.ts
+++ b/backend/src/file_manager/file_manager.service.ts
@@ -119,6 +119,8 @@ export class FileManagerService {
         ParentFolderID: file.ParentFolderID,
         Content: '',
         SafeLock: file.SafeLock,
+        NextDiffID: file.NextDiffID,
+        NextSnapshotID: file.NextSnapshotID,
       };
       markdownFilesDTOArr.push(markdownFileDTO);
     });

--- a/backend/src/markdown_files/dto/markdown_file.dto.ts
+++ b/backend/src/markdown_files/dto/markdown_file.dto.ts
@@ -9,6 +9,8 @@ export class MarkdownFileDTO {
   ParentFolderID: string;
   UserID: number;
   SafeLock: boolean;
+  NextDiffID: number;
+  NextSnapshotID: number;
 
   constructor() {
     this.MarkdownID = undefined;
@@ -21,5 +23,7 @@ export class MarkdownFileDTO {
     this.ParentFolderID = undefined;
     this.UserID = undefined;
     this.SafeLock = false;
+    this.NextDiffID = undefined;
+    this.NextSnapshotID = undefined;
   }
 }

--- a/backend/src/markdown_files/entities/markdown_file.entity.ts
+++ b/backend/src/markdown_files/entities/markdown_file.entity.ts
@@ -39,4 +39,10 @@ export class MarkdownFile {
 
   @Column()
   ParentFolderID: string; // hash string
+
+  @Column()
+  NextDiffID: number;
+
+  @Column()
+  NextSnapshotID: number;
 }

--- a/backend/test/file_manager.e2e-spec.ts
+++ b/backend/test/file_manager.e2e-spec.ts
@@ -142,6 +142,8 @@ describe('FileManagerController (integration)', () => {
       createFileDTO.Size = 0;
       createFileDTO.ParentFolderID = '';
       createFileDTO.SafeLock = false;
+      createFileDTO.NextDiffID = 0;
+      createFileDTO.NextSnapshotID = 0;
 
       const s3Response =
         await s3Service.createFile(createFileDTO);
@@ -155,7 +157,7 @@ describe('FileManagerController (integration)', () => {
       // console.log('s3Response: ', s3Response);
 
       await markdownFileRepository.query(
-        'INSERT INTO MARKDOWN_FILES (MarkdownID, Name, Path, Size, ParentFolderID, UserID, SafeLock) VALUES (?, ?, ?, ?, ?, ?, ?)',
+        'INSERT INTO MARKDOWN_FILES (MarkdownID, Name, Path, Size, ParentFolderID, UserID, SafeLock, NextDiffID, NextSnapshotID) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
         [
           s3Response.MarkdownID,
           createFileDTO.Name,
@@ -164,6 +166,8 @@ describe('FileManagerController (integration)', () => {
           createFileDTO.ParentFolderID,
           createFileDTO.UserID,
           createFileDTO.SafeLock,
+          createFileDTO.NextDiffID,
+          createFileDTO.NextSnapshotID,
         ],
       );
     }
@@ -235,6 +239,9 @@ describe('FileManagerController (integration)', () => {
         requestMarkdownFileDTO.UserID = parseInt(
           process.env.TEST_USERID,
         );
+
+        requestMarkdownFileDTO.NextDiffID = 0;
+        requestMarkdownFileDTO.NextSnapshotID = 0;
 
         const response = await request(
           app.getHttpServer(),


### PR DESCRIPTION
Relatively simple changes were made:

1. Added NextDiffID and NextSnapshotID to Markdown_Files relation to facilitate I/O on circular arrays for diffs and snapshots
2. Added these fields to MarkdownFileDTOs
3. Added these fields to the unit tests that deal with MarkdownFileDTOs

Unit tests pass, backend builds without error, frontend builds without error